### PR TITLE
Critical Fix: Google url starts with "www."

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,7 @@
   "content_scripts": [{
     "css": ["material.min.css", "styles.css"],
     "js": ["jquery-3.2.1.min.js", "content.js"],
-    "matches": ["https://google.com/*", "https://www.google.co.in/*"]
+    "matches": ["https://www.google.com/*", "https://www.google.co.in/*"]
   }]
  
 }


### PR DESCRIPTION
Google normally redirects "google.com/*" to "www.google.com/*", therefore it was not working when the url is set to "google.com/*". Fix was tested.